### PR TITLE
Add uploads model with relations

### DIFF
--- a/app/Http/Controllers/GestionController.php
+++ b/app/Http/Controllers/GestionController.php
@@ -11,24 +11,40 @@ class GestionController extends Controller
 {
     public function index()
     {
-        return GestionResource::collection(Gestion::with('paciente')->paginate());
+        return GestionResource::collection(Gestion::with(['paciente','uploads'])->paginate());
     }
 
     public function store(StoreGestionRequest $request)
     {
-        $gestion = Gestion::create($request->validated());
-        return (new GestionResource($gestion))->response()->setStatusCode(201);
+        $data = $request->validated();
+        $uploads = $data['upload_ids'] ?? [];
+        unset($data['upload_ids']);
+
+        $gestion = Gestion::create($data);
+        if (!empty($uploads)) {
+            $gestion->uploads()->sync($uploads);
+        }
+
+        return (new GestionResource($gestion->load(['paciente','uploads'])))->response()->setStatusCode(201);
     }
 
     public function show(Gestion $gestion)
     {
-        return new GestionResource($gestion->load('paciente'));
+        return new GestionResource($gestion->load(['paciente','uploads']));
     }
 
     public function update(UpdateGestionRequest $request, Gestion $gestion)
     {
-        $gestion->update($request->validated());
-        return new GestionResource($gestion->load('paciente'));
+        $data = $request->validated();
+        $uploads = $data['upload_ids'] ?? null;
+        unset($data['upload_ids']);
+
+        $gestion->update($data);
+        if (!is_null($uploads)) {
+            $gestion->uploads()->sync($uploads);
+        }
+
+        return new GestionResource($gestion->load(['paciente','uploads']));
     }
 
     public function destroy(Gestion $gestion)

--- a/app/Http/Controllers/TutorController.php
+++ b/app/Http/Controllers/TutorController.php
@@ -11,24 +11,40 @@ class TutorController extends Controller
 {
     public function index()
     {
-        return TutorResource::collection(Tutor::paginate());
+        return TutorResource::collection(Tutor::with('uploads')->paginate());
     }
 
     public function store(StoreTutorRequest $request)
     {
-        $tutor = Tutor::create($request->validated());
-        return (new TutorResource($tutor))->response()->setStatusCode(201);
+        $data = $request->validated();
+        $uploads = $data['upload_ids'] ?? [];
+        unset($data['upload_ids']);
+
+        $tutor = Tutor::create($data);
+        if (!empty($uploads)) {
+            $tutor->uploads()->sync($uploads);
+        }
+
+        return (new TutorResource($tutor->load('uploads')))->response()->setStatusCode(201);
     }
 
     public function show(Tutor $tutore) // nombre por convención
     {
-        return new TutorResource($tutore);
+        return new TutorResource($tutore->load('uploads'));
     }
 
     public function update(UpdateTutorRequest $request, Tutor $tutore)
     {
-        $tutore->update($request->validated());
-        return new TutorResource($tutore);
+        $data = $request->validated();
+        $uploads = $data['upload_ids'] ?? null;
+        unset($data['upload_ids']);
+
+        $tutore->update($data);
+        if (!is_null($uploads)) {
+            $tutore->uploads()->sync($uploads);
+        }
+
+        return new TutorResource($tutore->load('uploads'));
     }
 
     public function destroy(Tutor $tutore)

--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreUploadRequest;
+use App\Http\Requests\UpdateUploadRequest;
+use App\Http\Resources\UploadResource;
+use App\Models\Upload;
+
+class UploadController extends Controller
+{
+    public function index()
+    {
+        return UploadResource::collection(Upload::paginate());
+    }
+
+    public function store(StoreUploadRequest $request)
+    {
+        $upload = Upload::create($request->validated());
+        return (new UploadResource($upload))->response()->setStatusCode(201);
+    }
+
+    public function show(Upload $upload)
+    {
+        return new UploadResource($upload);
+    }
+
+    public function update(UpdateUploadRequest $request, Upload $upload)
+    {
+        $upload->update($request->validated());
+        return new UploadResource($upload);
+    }
+
+    public function destroy(Upload $upload)
+    {
+        $upload->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/StoreAgendamientoRequest.php
+++ b/app/Http/Requests/StoreAgendamientoRequest.php
@@ -39,6 +39,8 @@ class StoreAgendamientoRequest extends FormRequest
             'consentimiento' => ['boolean'],
             'total'          => ['numeric','min:0'],
             'observaciones'  => ['nullable','string'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/StoreAtencionRequest.php
+++ b/app/Http/Requests/StoreAtencionRequest.php
@@ -23,6 +23,8 @@ class StoreAtencionRequest extends FormRequest
             'anestesia_id' => ['nullable','integer','min:0'],
             'anamnesis'    => ['nullable','string'],
             'observaciones'=> ['nullable','string'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/StoreGestionRequest.php
+++ b/app/Http/Requests/StoreGestionRequest.php
@@ -19,6 +19,8 @@ class StoreGestionRequest extends FormRequest
             'autor'           => ['nullable','string','max:255'],
             'proximo_llamado' => ['nullable','date'],
             'observacion'     => ['nullable','string'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/StorePacienteRequest.php
+++ b/app/Http/Requests/StorePacienteRequest.php
@@ -15,6 +15,8 @@ class StorePacienteRequest extends FormRequest
     {
         return [
             'nombre' => ['required','string','max:255'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/StorePagoRequest.php
+++ b/app/Http/Requests/StorePagoRequest.php
@@ -18,6 +18,8 @@ class StorePagoRequest extends FormRequest
             'monto'        => ['required','numeric','min:0'],
             'fecha_pago'   => ['nullable','date'],
             'observacion'  => ['nullable','string','max:255'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/StoreTutorRequest.php
+++ b/app/Http/Requests/StoreTutorRequest.php
@@ -20,6 +20,8 @@ class StoreTutorRequest extends FormRequest
             'email'      => ['nullable','email','max:255'],
             'telefono_1' => ['nullable','string','max:50'],
             'telefono_2' => ['nullable','string','max:50'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/StoreUploadRequest.php
+++ b/app/Http/Requests/StoreUploadRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUploadRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->hasModule('uploads') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'filename'  => ['required','string','max:255'],
+            'url'       => ['required','url'],
+            'mime_type' => ['nullable','string','max:50'],
+            'size'      => ['nullable','integer','min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateAgendamientoRequest.php
+++ b/app/Http/Requests/UpdateAgendamientoRequest.php
@@ -39,6 +39,8 @@ class UpdateAgendamientoRequest extends FormRequest
             'consentimiento' => ['sometimes','boolean'],
             'total'          => ['sometimes','numeric','min:0'],
             'observaciones'  => ['sometimes','nullable','string'],
+            'upload_ids' => ['sometimes','array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateAtencionRequest.php
+++ b/app/Http/Requests/UpdateAtencionRequest.php
@@ -23,6 +23,8 @@ class UpdateAtencionRequest extends FormRequest
             'anestesia_id' => ['sometimes','nullable','integer','min:0'],
             'anamnesis'    => ['sometimes','nullable','string'],
             'observaciones'=> ['sometimes','nullable','string'],
+            'upload_ids' => ['sometimes','array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateGestionRequest.php
+++ b/app/Http/Requests/UpdateGestionRequest.php
@@ -19,6 +19,8 @@ class UpdateGestionRequest extends FormRequest
             'autor'           => ['sometimes','nullable','string','max:255'],
             'proximo_llamado' => ['sometimes','nullable','date'],
             'observacion'     => ['sometimes','nullable','string'],
+            'upload_ids' => ['sometimes','array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdatePacienteRequest.php
+++ b/app/Http/Requests/UpdatePacienteRequest.php
@@ -15,6 +15,8 @@ class UpdatePacienteRequest extends FormRequest
     {
         return [
             'nombre' => ['sometimes','string','max:255'],
+            'upload_ids' => ['sometimes','array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdatePagoRequest.php
+++ b/app/Http/Requests/UpdatePagoRequest.php
@@ -18,6 +18,8 @@ class UpdatePagoRequest extends FormRequest
             'monto'        => ['sometimes','numeric','min:0'],
             'fecha_pago'   => ['sometimes','nullable','date'],
             'observacion'  => ['sometimes','nullable','string','max:255'],
+            'upload_ids' => ['sometimes','array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateTutorRequest.php
+++ b/app/Http/Requests/UpdateTutorRequest.php
@@ -20,6 +20,8 @@ class UpdateTutorRequest extends FormRequest
             'email'      => ['sometimes','nullable','email','max:255'],
             'telefono_1' => ['sometimes','nullable','string','max:50'],
             'telefono_2' => ['sometimes','nullable','string','max:50'],
+            'upload_ids' => ['sometimes','array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateUploadRequest.php
+++ b/app/Http/Requests/UpdateUploadRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateUploadRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->hasModule('uploads') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'filename'  => ['sometimes','string','max:255'],
+            'url'       => ['sometimes','url'],
+            'mime_type' => ['sometimes','nullable','string','max:50'],
+            'size'      => ['sometimes','nullable','integer','min:0'],
+        ];
+    }
+}

--- a/app/Http/Resources/AgendamientoResource.php
+++ b/app/Http/Resources/AgendamientoResource.php
@@ -39,6 +39,7 @@ class AgendamientoResource extends JsonResource
                 'productos' => ProductoResource::collection($this->whenLoaded('productos')),
                 'servicios' => ServicioResource::collection($this->whenLoaded('servicios')),
                 'pagos'     => PagoResource::collection($this->whenLoaded('pagos')),
+                'uploads'   => UploadResource::collection($this->whenLoaded('uploads')),
             ],
         ];
     }

--- a/app/Http/Resources/AtencionResource.php
+++ b/app/Http/Resources/AtencionResource.php
@@ -25,6 +25,7 @@ class AtencionResource extends JsonResource
                 'paciente' => new PacienteResource($this->whenLoaded('paciente')),
                 'tutor'    => new TutorResource($this->whenLoaded('tutor')),
                 'especie'  => new EspecieResource($this->whenLoaded('especie')),
+                'uploads'  => UploadResource::collection($this->whenLoaded('uploads')),
             ],
         ];
     }

--- a/app/Http/Resources/GestionResource.php
+++ b/app/Http/Resources/GestionResource.php
@@ -21,6 +21,7 @@ class GestionResource extends JsonResource
             ],
             'relationships' => [
                 'paciente' => new PacienteResource($this->whenLoaded('paciente')),
+                'uploads'  => UploadResource::collection($this->whenLoaded('uploads')),
             ],
         ];
     }

--- a/app/Http/Resources/PagoResource.php
+++ b/app/Http/Resources/PagoResource.php
@@ -20,6 +20,7 @@ class PagoResource extends JsonResource
             ],
             'relationships' => [
                 'tipo_pago' => new TipoPagoResource($this->whenLoaded('tipoPago')),
+                'uploads'   => UploadResource::collection($this->whenLoaded('uploads')),
             ],
         ];
     }

--- a/app/Http/Resources/TutorResource.php
+++ b/app/Http/Resources/TutorResource.php
@@ -21,6 +21,9 @@ class TutorResource extends JsonResource
                 'created_at' => $this->created_at,
                 'updated_at' => $this->updated_at,
             ],
+            'relationships' => [
+                'uploads' => UploadResource::collection($this->whenLoaded('uploads')),
+            ],
         ];
     }
 }

--- a/app/Http/Resources/UploadResource.php
+++ b/app/Http/Resources/UploadResource.php
@@ -4,20 +4,20 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class PacienteResource extends JsonResource
+class UploadResource extends JsonResource
 {
     public function toArray($request): array
     {
         return [
-            'type' => 'pacientes',
+            'type' => 'uploads',
             'id' => (string) $this->id,
             'attributes' => [
-                'nombre' => $this->nombre,
+                'filename' => $this->filename,
+                'url' => $this->url,
+                'mime_type' => $this->mime_type,
+                'size' => $this->size,
                 'created_at' => $this->created_at,
                 'updated_at' => $this->updated_at,
-            ],
-            'relationships' => [
-                'uploads' => UploadResource::collection($this->whenLoaded('uploads')),
             ],
         ];
     }

--- a/app/Models/Agendamiento.php
+++ b/app/Models/Agendamiento.php
@@ -23,4 +23,5 @@ class Agendamiento extends Model {
   public function productos(){ return $this->belongsToMany(Producto::class)->withPivot(['cantidad','precio'])->withTimestamps(); }
   public function servicios(){ return $this->belongsToMany(Servicio::class)->withPivot(['cantidad','precio'])->withTimestamps(); }
   public function pagos(){ return $this->belongsToMany(Pago::class)->withTimestamps(); }
+  public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
 }

--- a/app/Models/Atencion.php
+++ b/app/Models/Atencion.php
@@ -26,4 +26,5 @@ class Atencion extends Model
     public function paciente(){ return $this->belongsTo(Paciente::class); }
     public function tutor(){ return $this->belongsTo(Tutor::class); }
     public function especie(){ return $this->belongsTo(Especie::class); }
+      public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
 }

--- a/app/Models/Gestion.php
+++ b/app/Models/Gestion.php
@@ -21,4 +21,5 @@ class Gestion extends Model
     ];
 
     public function paciente(){ return $this->belongsTo(Paciente::class); }
+      public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
 }

--- a/app/Models/Paciente.php
+++ b/app/Models/Paciente.php
@@ -16,4 +16,5 @@ class Paciente extends Model
     // Opcionales
     public function atenciones(){ return $this->hasMany(Atencion::class); }
     public function gestiones(){ return $this->hasMany(Gestion::class); }
+      public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
 }

--- a/app/Models/Pago.php
+++ b/app/Models/Pago.php
@@ -19,4 +19,5 @@ class Pago extends Model
     ];
 
     public function tipoPago(){ return $this->belongsTo(TipoPago::class, 'tipo_pago_id'); }
+      public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
 }

--- a/app/Models/Tutor.php
+++ b/app/Models/Tutor.php
@@ -17,4 +17,5 @@ class Tutor extends Model
 
     // Opcional
     public function atenciones(){ return $this->hasMany(Atencion::class); }
+      public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
 }

--- a/app/Models/Upload.php
+++ b/app/Models/Upload.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Upload extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = ['filename','url','mime_type','size'];
+
+    public function agendamientos(){ return $this->belongsToMany(Agendamiento::class)->withTimestamps(); }
+    public function atenciones(){ return $this->belongsToMany(Atencion::class)->withTimestamps(); }
+    public function pagos(){ return $this->belongsToMany(Pago::class)->withTimestamps(); }
+    public function pacientes(){ return $this->belongsToMany(Paciente::class)->withTimestamps(); }
+    public function tutores(){ return $this->belongsToMany(Tutor::class)->withTimestamps(); }
+    public function gestiones(){ return $this->belongsToMany(Gestion::class)->withTimestamps(); }
+}

--- a/database/migrations/2025_08_23_000000_create_uploads_table.php
+++ b/database/migrations/2025_08_23_000000_create_uploads_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('uploads', function (Blueprint $table) {
+            $table->id();
+            $table->string('filename', 255);
+            $table->text('url');
+            $table->string('mime_type', 50)->nullable();
+            $table->unsignedBigInteger('size')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('uploads');
+    }
+};

--- a/database/migrations/2025_08_23_000001_create_agendamiento_upload_table.php
+++ b/database/migrations/2025_08_23_000001_create_agendamiento_upload_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('agendamiento_upload', function (Blueprint $table) {
+            $table->foreignId('agendamiento_id')->constrained('agendamientos')->cascadeOnDelete();
+            $table->foreignId('upload_id')->constrained('uploads')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['agendamiento_id','upload_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agendamiento_upload');
+    }
+};

--- a/database/migrations/2025_08_23_000002_create_atencion_upload_table.php
+++ b/database/migrations/2025_08_23_000002_create_atencion_upload_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('atencion_upload', function (Blueprint $table) {
+            $table->foreignId('atencion_id')->constrained('atenciones')->cascadeOnDelete();
+            $table->foreignId('upload_id')->constrained('uploads')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['atencion_id','upload_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('atencion_upload');
+    }
+};

--- a/database/migrations/2025_08_23_000003_create_pago_upload_table.php
+++ b/database/migrations/2025_08_23_000003_create_pago_upload_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('pago_upload', function (Blueprint $table) {
+            $table->foreignId('pago_id')->constrained('pagos')->cascadeOnDelete();
+            $table->foreignId('upload_id')->constrained('uploads')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['pago_id','upload_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pago_upload');
+    }
+};

--- a/database/migrations/2025_08_23_000004_create_paciente_upload_table.php
+++ b/database/migrations/2025_08_23_000004_create_paciente_upload_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('paciente_upload', function (Blueprint $table) {
+            $table->foreignId('paciente_id')->constrained('pacientes')->cascadeOnDelete();
+            $table->foreignId('upload_id')->constrained('uploads')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['paciente_id','upload_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('paciente_upload');
+    }
+};

--- a/database/migrations/2025_08_23_000005_create_tutor_upload_table.php
+++ b/database/migrations/2025_08_23_000005_create_tutor_upload_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tutor_upload', function (Blueprint $table) {
+            $table->foreignId('tutor_id')->constrained('tutores')->cascadeOnDelete();
+            $table->foreignId('upload_id')->constrained('uploads')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['tutor_id','upload_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tutor_upload');
+    }
+};

--- a/database/migrations/2025_08_23_000006_create_gestion_upload_table.php
+++ b/database/migrations/2025_08_23_000006_create_gestion_upload_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('gestion_upload', function (Blueprint $table) {
+            $table->foreignId('gestion_id')->constrained('gestiones')->cascadeOnDelete();
+            $table->foreignId('upload_id')->constrained('uploads')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['gestion_id','upload_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('gestion_upload');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\TipoPagoController;
 use App\Http\Controllers\OrigenController;
 use App\Http\Controllers\GestionController;
 use App\Http\Controllers\AgendamientoController;
+use App\Http\Controllers\UploadController;
 
 /*
 |--------------------------------------------------------------------------
@@ -89,6 +90,7 @@ Route::middleware(['auth:sanctum'])->group(function () {
         Route::apiResource('pagos', PagoController::class)->middleware('module:pagos');
 
         Route::apiResource('gestiones', GestionController::class)->middleware('module:calendario');
+        Route::apiResource('uploads', UploadController::class)->middleware('module:uploads');
 
         // -------- Agendamientos + vínculos M:M --------
         Route::apiResource('agendamientos', AgendamientoController::class)->middleware('module:calendario');


### PR DESCRIPTION
## Summary
- add `uploads` table and pivot tables to link uploads with agendamientos, atenciones, pagos, pacientes, tutores and gestiones
- expose CRUD controller, requests and resource for uploads
- extend existing models, requests, controllers and resources to manage associated uploads and register new API route

## Testing
- `composer dump-autoload` *(fails: Class Illuminate\Foundation\ComposerScripts is not autoloadable)*
- `phpunit` *(fails: command not found)*
- `php artisan test` *(fails: Class "Illuminate\Foundation\Application" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc6b57ad08328ae0bdf3407009f10