### PR TITLE
feat: add operativos entity

### DIFF
--- a/app/Http/Controllers/AgendamientoController.php
+++ b/app/Http/Controllers/AgendamientoController.php
@@ -16,7 +16,7 @@ class AgendamientoController extends Controller
     public function index()
     {
         return AgendamientoResource::collection(
-            Agendamiento::with(['paciente','tutor','especie','fase','uploads'])->paginate()
+            Agendamiento::with(['paciente','tutor','especie','fase','uploads','operativos'])->paginate()
         );
     }
 
@@ -37,7 +37,7 @@ class AgendamientoController extends Controller
     public function show(Agendamiento $agendamiento)
     {
         return new AgendamientoResource(
-            $agendamiento->load(['paciente','tutor','especie','fase','productos','servicios','pagos','uploads'])
+            $agendamiento->load(['paciente','tutor','especie','fase','productos','servicios','pagos','uploads','operativos'])
         );
     }
 
@@ -52,7 +52,7 @@ class AgendamientoController extends Controller
             $agendamiento->uploads()->sync($uploads);
         }
 
-        return new AgendamientoResource($agendamiento->fresh()->load(['paciente','tutor','especie','fase','uploads']));
+        return new AgendamientoResource($agendamiento->fresh()->load(['paciente','tutor','especie','fase','uploads','operativos']));
     }
 
     public function destroy(Agendamiento $agendamiento)

--- a/app/Http/Controllers/OperativoController.php
+++ b/app/Http/Controllers/OperativoController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreOperativoRequest;
+use App\Http\Requests\UpdateOperativoRequest;
+use App\Http\Resources\OperativoResource;
+use App\Models\Operativo;
+
+class OperativoController extends Controller
+{
+    public function index()
+    {
+        return OperativoResource::collection(Operativo::with('agendamientos')->paginate());
+    }
+
+    public function store(StoreOperativoRequest $request)
+    {
+        $data = $request->validated();
+        $agendamientos = $data['agendamiento_ids'] ?? [];
+        unset($data['agendamiento_ids']);
+
+        $operativo = Operativo::create($data);
+        if (!empty($agendamientos)) {
+            $operativo->agendamientos()->sync($agendamientos);
+        }
+
+        return (new OperativoResource($operativo->load('agendamientos')))->response()->setStatusCode(201);
+    }
+
+    public function show(Operativo $operativo)
+    {
+        return new OperativoResource($operativo->load('agendamientos'));
+    }
+
+    public function update(UpdateOperativoRequest $request, Operativo $operativo)
+    {
+        $data = $request->validated();
+        $agendamientos = $data['agendamiento_ids'] ?? null;
+        unset($data['agendamiento_ids']);
+
+        $operativo->update($data);
+        if (!is_null($agendamientos)) {
+            $operativo->agendamientos()->sync($agendamientos);
+        }
+
+        return new OperativoResource($operativo->load('agendamientos'));
+    }
+
+    public function destroy(Operativo $operativo)
+    {
+        $operativo->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/StoreOperativoRequest.php
+++ b/app/Http/Requests/StoreOperativoRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreOperativoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->hasModule('operativos') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'titulo' => ['required','string','max:255'],
+            'descripcion' => ['required','string','max:255'],
+            'fecha_inicio' => ['required','date'],
+            'fecha_termino' => ['required','date'],
+            'agendamiento_ids' => ['array'],
+            'agendamiento_ids.*' => ['exists:agendamientos,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateOperativoRequest.php
+++ b/app/Http/Requests/UpdateOperativoRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateOperativoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->hasModule('operativos') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'titulo' => ['sometimes','string','max:255'],
+            'descripcion' => ['sometimes','string','max:255'],
+            'fecha_inicio' => ['sometimes','date'],
+            'fecha_termino' => ['sometimes','date'],
+            'agendamiento_ids' => ['array'],
+            'agendamiento_ids.*' => ['exists:agendamientos,id'],
+        ];
+    }
+}

--- a/app/Http/Resources/AgendamientoResource.php
+++ b/app/Http/Resources/AgendamientoResource.php
@@ -40,6 +40,7 @@ class AgendamientoResource extends JsonResource
                 'servicios' => ServicioResource::collection($this->whenLoaded('servicios')),
                 'pagos'     => PagoResource::collection($this->whenLoaded('pagos')),
                 'uploads'   => UploadResource::collection($this->whenLoaded('uploads')),
+                'operativos' => OperativoResource::collection($this->whenLoaded('operativos')),
             ],
         ];
     }

--- a/app/Http/Resources/OperativoResource.php
+++ b/app/Http/Resources/OperativoResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class OperativoResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'type' => 'operativos',
+            'id' => (string) $this->id,
+            'attributes' => [
+                'titulo' => $this->titulo,
+                'descripcion' => $this->descripcion,
+                'fecha_inicio' => $this->fecha_inicio,
+                'fecha_termino' => $this->fecha_termino,
+                'created_at' => $this->created_at,
+                'updated_at' => $this->updated_at,
+            ],
+            'relationships' => [
+                'agendamientos' => AgendamientoResource::collection($this->whenLoaded('agendamientos')),
+            ],
+        ];
+    }
+}

--- a/app/Models/Agendamiento.php
+++ b/app/Models/Agendamiento.php
@@ -20,8 +20,9 @@ class Agendamiento extends Model {
   public function atencion(){ return $this->belongsTo(Atencion::class); }
   public function especie(){ return $this->belongsTo(Especie::class); }
 
-  public function productos(){ return $this->belongsToMany(Producto::class)->withPivot(['cantidad','precio'])->withTimestamps(); }
-  public function servicios(){ return $this->belongsToMany(Servicio::class)->withPivot(['cantidad','precio'])->withTimestamps(); }
-  public function pagos(){ return $this->belongsToMany(Pago::class)->withTimestamps(); }
-  public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
-}
+   public function productos(){ return $this->belongsToMany(Producto::class)->withPivot(['cantidad','precio'])->withTimestamps(); }
+   public function servicios(){ return $this->belongsToMany(Servicio::class)->withPivot(['cantidad','precio'])->withTimestamps(); }
+   public function pagos(){ return $this->belongsToMany(Pago::class)->withTimestamps(); }
+   public function uploads(){ return $this->belongsToMany(Upload::class)->withTimestamps(); }
+   public function operativos(){ return $this->belongsToMany(Operativo::class, 'operativo_agendamiento')->withTimestamps(); }
+  }

--- a/app/Models/Operativo.php
+++ b/app/Models/Operativo.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Operativo extends Model {
+  use SoftDeletes;
+  protected $fillable = [
+    'titulo','descripcion','fecha_inicio','fecha_termino'
+  ];
+
+  public function agendamientos(){
+    return $this->belongsToMany(Agendamiento::class, 'operativo_agendamiento')->withTimestamps();
+  }
+}

--- a/database/migrations/2025_08_23_000002_create_operativos_table.php
+++ b/database/migrations/2025_08_23_000002_create_operativos_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+  public function up(): void {
+    Schema::create('operativos', function (Blueprint $t) {
+      $t->id();
+      $t->string('titulo');
+      $t->string('descripcion');
+      $t->dateTime('fecha_inicio');
+      $t->dateTime('fecha_termino');
+      $t->timestamps();
+      $t->softDeletes();
+    });
+  }
+  public function down(): void { Schema::dropIfExists('operativos'); }
+};

--- a/database/migrations/2025_08_23_000003_create_operativo_agendamiento_table.php
+++ b/database/migrations/2025_08_23_000003_create_operativo_agendamiento_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+  public function up(): void {
+    Schema::create('operativo_agendamiento', function (Blueprint $t) {
+      $t->foreignId('operativo_id')->constrained('operativos')->cascadeOnDelete();
+      $t->foreignId('agendamiento_id')->constrained('agendamientos')->cascadeOnDelete();
+      $t->timestamps();
+      $t->primary(['operativo_id','agendamiento_id']);
+    });
+  }
+  public function down(): void { Schema::dropIfExists('operativo_agendamiento'); }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\OrigenController;
 use App\Http\Controllers\GestionController;
 use App\Http\Controllers\AgendamientoController;
 use App\Http\Controllers\UploadController;
+use App\Http\Controllers\OperativoController;
 
 /*
 |--------------------------------------------------------------------------
@@ -91,6 +92,7 @@ Route::middleware(['auth:sanctum'])->group(function () {
 
         Route::apiResource('gestiones', GestionController::class)->middleware('module:calendario');
         Route::apiResource('uploads', UploadController::class)->middleware('module:uploads');
+        Route::apiResource('operativos', OperativoController::class)->middleware('module:operativos');
 
         // -------- Agendamientos + vínculos M:M --------
         Route::apiResource('agendamientos', AgendamientoController::class)->middleware('module:calendario');


### PR DESCRIPTION
## Summary
- add Operativo model, migrations, controller, requests and resource
- link Operativos to Agendamientos with pivot table and API routes
- expose operativos through REST endpoints

## Testing
- `composer install` *(fails: failed to download packages, requires GitHub credentials)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0347dab2083288a19685c4ed9bbf0