### PR TITLE
Add observations and uploads relation to operativos

### DIFF
--- a/app/Http/Controllers/OperativoController.php
+++ b/app/Http/Controllers/OperativoController.php
@@ -11,40 +11,48 @@ class OperativoController extends Controller
 {
     public function index()
     {
-        return OperativoResource::collection(Operativo::with('agendamientos')->paginate());
+        return OperativoResource::collection(Operativo::with(['agendamientos','uploads'])->paginate());
     }
 
     public function store(StoreOperativoRequest $request)
     {
         $data = $request->validated();
         $agendamientos = $data['agendamiento_ids'] ?? [];
-        unset($data['agendamiento_ids']);
+        $uploads = $data['upload_ids'] ?? [];
+        unset($data['agendamiento_ids'], $data['upload_ids']);
 
         $operativo = Operativo::create($data);
         if (!empty($agendamientos)) {
             $operativo->agendamientos()->sync($agendamientos);
         }
+        if (!empty($uploads)) {
+            $operativo->uploads()->sync($uploads);
+        }
 
-        return (new OperativoResource($operativo->load('agendamientos')))->response()->setStatusCode(201);
+        return (new OperativoResource($operativo->load(['agendamientos','uploads'])))->response()->setStatusCode(201);
     }
 
     public function show(Operativo $operativo)
     {
-        return new OperativoResource($operativo->load('agendamientos'));
+        return new OperativoResource($operativo->load(['agendamientos','uploads']));
     }
 
     public function update(UpdateOperativoRequest $request, Operativo $operativo)
     {
         $data = $request->validated();
         $agendamientos = $data['agendamiento_ids'] ?? null;
-        unset($data['agendamiento_ids']);
+        $uploads = $data['upload_ids'] ?? null;
+        unset($data['agendamiento_ids'], $data['upload_ids']);
 
         $operativo->update($data);
         if (!is_null($agendamientos)) {
             $operativo->agendamientos()->sync($agendamientos);
         }
+        if (!is_null($uploads)) {
+            $operativo->uploads()->sync($uploads);
+        }
 
-        return new OperativoResource($operativo->load('agendamientos'));
+        return new OperativoResource($operativo->load(['agendamientos','uploads']));
     }
 
     public function destroy(Operativo $operativo)

--- a/app/Http/Requests/StoreOperativoRequest.php
+++ b/app/Http/Requests/StoreOperativoRequest.php
@@ -18,8 +18,11 @@ class StoreOperativoRequest extends FormRequest
             'descripcion' => ['required','string','max:255'],
             'fecha_inicio' => ['required','date'],
             'fecha_termino' => ['required','date'],
+            'observaciones' => ['nullable','string'],
             'agendamiento_ids' => ['array'],
             'agendamiento_ids.*' => ['exists:agendamientos,id'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateOperativoRequest.php
+++ b/app/Http/Requests/UpdateOperativoRequest.php
@@ -18,8 +18,11 @@ class UpdateOperativoRequest extends FormRequest
             'descripcion' => ['sometimes','string','max:255'],
             'fecha_inicio' => ['sometimes','date'],
             'fecha_termino' => ['sometimes','date'],
+            'observaciones' => ['sometimes','nullable','string'],
             'agendamiento_ids' => ['array'],
             'agendamiento_ids.*' => ['exists:agendamientos,id'],
+            'upload_ids' => ['array'],
+            'upload_ids.*' => ['exists:uploads,id'],
         ];
     }
 }

--- a/app/Http/Resources/OperativoResource.php
+++ b/app/Http/Resources/OperativoResource.php
@@ -16,11 +16,13 @@ class OperativoResource extends JsonResource
                 'descripcion' => $this->descripcion,
                 'fecha_inicio' => $this->fecha_inicio,
                 'fecha_termino' => $this->fecha_termino,
+                'observaciones' => $this->observaciones,
                 'created_at' => $this->created_at,
                 'updated_at' => $this->updated_at,
             ],
             'relationships' => [
                 'agendamientos' => AgendamientoResource::collection($this->whenLoaded('agendamientos')),
+                'uploads' => UploadResource::collection($this->whenLoaded('uploads')),
             ],
         ];
     }

--- a/app/Models/Operativo.php
+++ b/app/Models/Operativo.php
@@ -8,10 +8,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Operativo extends Model {
   use SoftDeletes;
   protected $fillable = [
-    'titulo','descripcion','fecha_inicio','fecha_termino'
+    'titulo','descripcion','fecha_inicio','fecha_termino','observaciones'
   ];
 
   public function agendamientos(){
     return $this->belongsToMany(Agendamiento::class, 'operativo_agendamiento')->withTimestamps();
+  }
+
+  public function uploads(){
+    return $this->belongsToMany(Upload::class)->withTimestamps();
   }
 }

--- a/app/Models/Upload.php
+++ b/app/Models/Upload.php
@@ -17,4 +17,5 @@ class Upload extends Model
     public function pacientes(){ return $this->belongsToMany(Paciente::class)->withTimestamps(); }
     public function tutores(){ return $this->belongsToMany(Tutor::class)->withTimestamps(); }
     public function gestiones(){ return $this->belongsToMany(Gestion::class)->withTimestamps(); }
+    public function operativos(){ return $this->belongsToMany(Operativo::class)->withTimestamps(); }
 }

--- a/database/migrations/2025_08_23_000007_add_observaciones_to_operativos_table.php
+++ b/database/migrations/2025_08_23_000007_add_observaciones_to_operativos_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('operativos', function (Blueprint $table) {
+            $table->text('observaciones')->nullable()->after('fecha_termino');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('operativos', function (Blueprint $table) {
+            $table->dropColumn('observaciones');
+        });
+    }
+};

--- a/database/migrations/2025_08_23_000008_create_operativo_upload_table.php
+++ b/database/migrations/2025_08_23_000008_create_operativo_upload_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('operativo_upload', function (Blueprint $table) {
+            $table->foreignId('operativo_id')->constrained('operativos')->cascadeOnDelete();
+            $table->foreignId('upload_id')->constrained('uploads')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['operativo_id','upload_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('operativo_upload');
+    }
+};

--- a/tests/Unit/OperativoUploadTest.php
+++ b/tests/Unit/OperativoUploadTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Operativo;
+use App\Models\Upload;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class OperativoUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_observaciones_column_and_pivot_table_exist(): void
+    {
+        $this->assertTrue(Schema::hasColumn('operativos', 'observaciones'));
+        $this->assertTrue(Schema::hasTable('operativo_upload'));
+    }
+
+    public function test_operativo_can_attach_upload(): void
+    {
+        $operativo = Operativo::create([
+            'titulo' => 'Operativo',
+            'descripcion' => 'Desc',
+            'fecha_inicio' => now(),
+            'fecha_termino' => now(),
+        ]);
+
+        $upload = Upload::create([
+            'filename' => 'file.txt',
+            'url' => '/file.txt',
+            'mime_type' => 'text/plain',
+            'size' => 1,
+        ]);
+
+        $operativo->uploads()->attach($upload->id);
+
+        $this->assertDatabaseHas('operativo_upload', [
+            'operativo_id' => $operativo->id,
+            'upload_id' => $upload->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `observaciones` field to operativos
- allow operativos to relate uploads
- test operativo-upload relationship

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b050ae92e4832898cdc4daf9a4ad8c